### PR TITLE
requirements.txt: Add Python-conventional requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+skyfield
+arrow==0.14
+pytz
+ics


### PR DESCRIPTION
Simple file for using like this:

```
pip3 install `cat requirements.txt`
```

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>